### PR TITLE
Support for E.164 format in checkPhonePattern method

### DIFF
--- a/client/src/Auth/Register.jsx
+++ b/client/src/Auth/Register.jsx
@@ -156,7 +156,7 @@ export default class Register extends Component {
     }
 
     checkPhonePattern = (phone) => {
-        return /\+1[0-9]{3}[0-9]{3}[0-9]{4}$/.test(phone);
+        return /^\+?[1-9]\d{1,14}$/.test(phone);
     }
 
     countDownResendVerificationCode = () => {


### PR DESCRIPTION
Updated `checkPhonePattern` method to support E.164 phone numbers. This is as described in the AWS SNS API documentation. (http://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html)

Also see:  https://stackoverflow.com/questions/6478875/regular-expression-matching-e-164-formatted-phone-numbers#comment45228115_23299989
Closes #2