### PR TITLE
Fixed typo: 'opacity: 0,01' --> 'opacity: 0.01'

### DIFF
--- a/client/src/css/general.css
+++ b/client/src/css/general.css
@@ -33,7 +33,7 @@
   opacity: 1;
 }
 .sample-app-leave.sample-app-leave-active {
-  opacity: 0,01;
+  opacity: 0.01;
   transition: opacity 300ms ease-in;
 }
 


### PR DESCRIPTION
Fixed a minor typo in css. _See commit message_